### PR TITLE
docs(examples): fix broken example

### DIFF
--- a/src/main/java/io/kestra/plugin/ollama/cli/OllamaCLI.java
+++ b/src/main/java/io/kestra/plugin/ollama/cli/OllamaCLI.java
@@ -62,9 +62,9 @@ import java.util.Map;
                   - id: list_models
                     type: io.kestra.plugin.ollama.cli.OllamaCLI
                     commands:
-                      - ollama list --format json > models.json
+                      - ollama list > models.txt
                     outputFiles:
-                      - models.json
+                      - models.txt
                 """
         )
     }


### PR DESCRIPTION
Fix examples to work proper.y

`--format json` doesn't exist. so changing to just put in a `.txt` file.