### PR TITLE
fix(test): raise RunnerTest await timeout and bound sanity-check prompt

### DIFF
--- a/src/test/java/io/kestra/plugin/ollama/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/ollama/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow(value = "sanity-checks/all_ollama.yaml", timeout = "PT180S")
+    @ExecuteFlow(value = "sanity-checks/all_ollama.yaml", timeout = "PT300S")
     void all_pulsar(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/src/test/resources/sanity-checks/all_ollama.yaml
+++ b/src/test/resources/sanity-checks/all_ollama.yaml
@@ -4,7 +4,8 @@ namespace: sanitychecks.plugin-ollama
 inputs:
   - id: prompt
     type: STRING
-    defaults: Tell me a joke about AI
+    # Keep the prompt minimal so CPU inference on CI runners stays fast and bounded.
+    defaults: Reply with a single word.
 
 tasks:
   - id: ollama_cli_task


### PR DESCRIPTION
## What

Fixes the flaky/timed-out `RunnerTest.all_pulsar` sanity check.

## Why

In [CI run #27668649195](https://github.com/kestra-io/plugin-ollama/actions/runs/27668649195/job/81827886296) the test failed with:

```
ParameterResolutionException: Execution ... is currently at the status RUNNING which is not the awaited one
```

The execution was still `RUNNING` after the **180s** await window. From the logs, the `smollm:135m` download (91 MB) took only ~3s — the time was dominated by container/`ollama serve` startup plus open-ended **CPU inference** of "Tell me a joke about AI".

## How

1. **Raise the await timeout** `PT180S` → `PT300S` (the load-bearing fix — covers slow CPU startup/inference on the runner).
2. **Bound the prompt** to `Reply with a single word.` to keep CPU inference short. `smollm:135m` is already the smallest practical model, and the sanity check only asserts `exitCode == 0` / `SUCCESS`, so response content is irrelevant. This is a best-effort speedup; it cannot increase generation time versus the previous open-ended prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)